### PR TITLE
Make the example in the README work

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We can tag specific tests with one or more tags.
 ```rb
 class MyTest < Minitest::Test
   tag 'my_tag', 'another_tag'
-  test '#hello minitag' do
+  def test_hello_minitest
     # ...
   end
 end


### PR DESCRIPTION
Use `def` instead of `test` as that's an `ActiveSupport::TestCase` thing

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"

  gem "minitest"
  gem "minitag"
end

require "minitest/autorun"

class MyTest < Minitest::Test
  tag "my_tag", "another_tag"
  test "#hello minitag" do
    # ...
  end
end
```

```
❯ ruby minitag.rb
Traceback (most recent call last):
        2: from minitag.rb:12:in `<main>'
        1: from minitag.rb:14:in `<class:MyTest>'
minitag.rb:14:in `test': unknown command '#' (ArgumentError)
```