### PR TITLE
Use String#start_with instead of String#[]

### DIFF
--- a/lib/minitag/tag_extension.rb
+++ b/lib/minitag/tag_extension.rb
@@ -21,7 +21,7 @@ module Minitag
     end
 
     define_method(:method_added) do |name|
-      if name[/\Atest_/]
+      if name.start_with?('test_')
         Minitag.context.add_tags(
           namespace: self, name: name, tags: Minitag.pending_tags
         )


### PR DESCRIPTION
<details><summary>Benchmark</summary>
<p>

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
end

require "benchmark/ips"

SCENARIOS = {
  "Empty"            => "",
  "Single Space"     => " ",
  "test_"            => "test_",
  "Very Long String" => "test_" * 100
}

SCENARIOS.each_pair do |name, value|
  puts
  puts " #{name} ".center(80, "=")
  puts

  Benchmark.ips do |x|
    x.report("[]")          { value[/\Atest_/] }
    x.report("start_with?") { value.start_with?("test_") }
    x.compare!
  end
end
```

</p>
</details>

<details><summary>Results</summary>
<p>

```Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using benchmark-ips 2.8.2
Using bundler 2.0.2

==================================== Empty =====================================

Warming up --------------------------------------
                  []   304.769k i/100ms
         start_with?     1.399M i/100ms
Calculating -------------------------------------
                  []      3.023M (± 2.0%) i/s -     15.238M in   5.042381s
         start_with?     13.792M (± 2.2%) i/s -     69.948M in   5.074224s

Comparison:
         start_with?: 13792142.9 i/s
                  []:  3023312.0 i/s - 4.56x  (± 0.00) slower


================================= Single Space =================================

Warming up --------------------------------------
                  []   293.089k i/100ms
         start_with?     1.393M i/100ms
Calculating -------------------------------------
                  []      2.914M (± 2.5%) i/s -     14.654M in   5.031457s
         start_with?     13.836M (± 2.1%) i/s -     69.659M in   5.037022s

Comparison:
         start_with?: 13835868.1 i/s
                  []:  2914451.2 i/s - 4.75x  (± 0.00) slower


==================================== test_ =====================================

Warming up --------------------------------------
                  []   374.372k i/100ms
         start_with?     1.315M i/100ms
Calculating -------------------------------------
                  []      3.795M (± 1.9%) i/s -     19.093M in   5.032352s
         start_with?     13.062M (± 2.3%) i/s -     65.747M in   5.036082s

Comparison:
         start_with?: 13062271.7 i/s
                  []:  3795427.6 i/s - 3.44x  (± 0.00) slower


=============================== Very Long String ===============================

Warming up --------------------------------------
                  []   364.010k i/100ms
         start_with?     1.318M i/100ms
Calculating -------------------------------------
                  []      3.638M (± 2.2%) i/s -     18.200M in   5.004818s
         start_with?     12.988M (± 2.8%) i/s -     65.900M in   5.078214s

Comparison:
         start_with?: 12987957.4 i/s
                  []:  3638487.2 i/s - 3.57x  (± 0.00) slower
```

</p>
</details>