### PR TITLE
Revert "Use String#start_with instead of String#[]"

### DIFF
--- a/lib/minitag/tag_extension.rb
+++ b/lib/minitag/tag_extension.rb
@@ -21,7 +21,7 @@ module Minitag
     end
 
     define_method(:method_added) do |name|
-      if name.start_with?('test_')
+      if name[/\Atest_/]
         Minitag.context.add_tags(
           namespace: self, name: name, tags: Minitag.pending_tags
         )


### PR DESCRIPTION
Reverts bernardoamc/minitag#9

@repinel Just remembered the reason why I used `[]` instead of `start_with?`. The name is this scenario is a `Symbol` and `start_with?` won't work. Interestingly enough CI didn't run and that's why we didn't caught this error. 