### PR TITLE
Add support for Ruby 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7' ]
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-ruby '>= 2.6'
+ruby '>= 2.5'
 
 # Specify your gem's dependencies in minitag.gemspec
 gemspec

--- a/lib/minitag/context.rb
+++ b/lib/minitag/context.rb
@@ -46,7 +46,7 @@ module Minitag
     # @return [void]
     def add_filter(tag)
       if tag.start_with?('~')
-        @exclusive_filters << tag[1..]
+        @exclusive_filters << tag[1..tag.length - 1]
       else
         @inclusive_filters << tag
       end

--- a/minitag.gemspec
+++ b/minitag.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'minitest', '~> 5.0'
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.5.0'
 end


### PR DESCRIPTION
This PR resolves #15, making the necessary tweaks to enable this gem to be used with Ruby 2.5, and run its tests against Ruby 2.5 in CI.