### PR TITLE
Support skipping tests instead of hiding them

### DIFF
--- a/lib/minitag.rb
+++ b/lib/minitag.rb
@@ -12,6 +12,8 @@ require 'minitag/tag_extension'
 # to Minitest::Test
 module Minitag
   class << self
+    attr_writer :skip_filtered
+
     # Registry of classes that requires extension by Minitag::TagExtension.
     def extension_registry
       @extension_registry ||= ExtensionRegistry.new
@@ -40,6 +42,11 @@ module Minitag
     # Tags set from the `tag` method.
     def pending_tags=(tags)
       @pending_tags = Array(tags)
+    end
+
+    # Whether to skip (true) or hide (false) filtered tests.
+    def skip_filtered?
+      @skip_filtered || false
     end
   end
 end

--- a/lib/minitest/minitag_plugin.rb
+++ b/lib/minitest/minitag_plugin.rb
@@ -10,11 +10,17 @@ module Minitest
       options[:tags] ||= []
       options[:tags] << tag.to_s.strip.downcase
     end
+
+    opts.on '--skip-filtered' do
+      options[:skip_filtered] = true
+    end
   end
 
   def self.plugin_minitag_init(options)
     Array(options[:tags]).each do |tag|
       Minitag.add_filter(tag)
     end
+
+    Minitag.skip_filtered = options.fetch(:skip_filtered, false)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,9 +5,14 @@ require 'minitag'
 
 require 'minitest/autorun'
 
-def with_context(filters: [])
+def with_context(filters: [], skip_filtered: false)
   filters.each { |filter| Minitag.context.add_filter(filter) }
-  yield
-  Minitag.context.instance_variable_set(:@inclusive_filters, Set.new)
-  Minitag.context.instance_variable_set(:@exclusive_filters, Set.new)
+  Minitag.skip_filtered = skip_filtered
+  begin
+    yield
+  ensure
+    Minitag.context.instance_variable_set(:@inclusive_filters, Set.new)
+    Minitag.context.instance_variable_set(:@exclusive_filters, Set.new)
+    Minitag.skip_filtered = false
+  end
 end


### PR DESCRIPTION
It's easy to lose track of the tests that have been disabled due to filtering. To help with that problem, this PR resolves #17 by supporting the skipping of tests instead of hiding them completely. It exposes this via an additional `--skip-filtered` CLI option. If set, it will skip filtered tests. If unset (the default), it will hide filtered tests like it does today.